### PR TITLE
icon component props, default style 설정

### DIFF
--- a/src/assets/styles/size/semantics.js
+++ b/src/assets/styles/size/semantics.js
@@ -51,5 +51,10 @@ module.exports = {
     $icon_md: iconSize.md,
     $icon_lg: iconSize.lg,
     $icon_xl: iconSize.xl,
+    $icon_xs_r: iconSize.xs_r,
+    $icon_sm_r: iconSize.sm_r,
+    $icon_md_r: iconSize.md_r,
+    $icon_lg_r: iconSize.lg_r,
+    $icon_xl_r: iconSize.xl_r,
   },
 }

--- a/src/components/Icon/Icon.scss
+++ b/src/components/Icon/Icon.scss
@@ -1,0 +1,34 @@
+@import '../../assets/styles/global.scss';
+
+$component: #{$prefix}-icon;
+
+.#{$component}-xs {
+  @apply w-icon_xs h-icon_xs;
+}
+.#{$component}-sm {
+  @apply w-icon_sm h-icon_sm;
+}
+.#{$component}-md {
+  @apply w-icon_md h-icon_md;
+}
+.#{$component}-lg {
+  @apply w-icon_lg h-icon_lg;
+}
+.#{$component}-xl {
+  @apply w-icon_xl h-icon_xl;
+}
+.#{$component}-responsive-xs {
+  @apply w-icon_xs_r h-icon_xs_r;
+}
+.#{$component}-responsive-sm {
+  @apply w-icon_sm_r h-icon_sm_r;
+}
+.#{$component}-responsive-md {
+  @apply w-icon_md_r h-icon_md_r;
+}
+.#{$component}-responsive-lg {
+  @apply w-icon_lg_r h-icon_lg_r;
+}
+.#{$component}-responsive-xl {
+  @apply w-icon_xl_r h-icon_xl_r;
+}

--- a/src/components/Icon/Icons/ChevronIcon.tsx
+++ b/src/components/Icon/Icons/ChevronIcon.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import SVGIcon from '@components/Icon/SVGIcon'
 import svgRotate from '@src/helpers/svgRotate'
 
-interface ChevronProps {
+interface IconProps {
   color?: string
   width?: number
   height?: number
@@ -13,7 +13,7 @@ interface ChevronProps {
   responsive?: boolean
 }
 
-const ChevronIcon = (props: ChevronProps) => {
+const ChevronIcon = (props: IconProps) => {
   const { viewBox, rotate } = props
 
   return (

--- a/src/components/Icon/Icons/ChevronIcon.tsx
+++ b/src/components/Icon/Icons/ChevronIcon.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
 
-import { $icon_md } from '@assets/styles/size/semantics'
-
 import SVGIcon from '@components/Icon/SVGIcon'
 import svgRotate from '@src/helpers/svgRotate'
 
@@ -29,7 +27,7 @@ const ChevronIcon = (props: IconProps) => {
 }
 
 ChevronIcon.defaultProps = {
-  viewBox: `0 0 ${$icon_md} ${$icon_md}`,
+  viewBox: '0 0 24 24',
   rotate: 0,
 }
 

--- a/src/components/Icon/Icons/ChevronIcon.tsx
+++ b/src/components/Icon/Icons/ChevronIcon.tsx
@@ -1,16 +1,10 @@
 import React from 'react'
 
-import SVGIcon from '@components/Icon/SVGIcon'
+import SVGIcon, { SVGIconProps } from '@components/Icon/SVGIcon'
 import svgRotate from '@src/helpers/svgRotate'
 
-interface IconProps {
-  color?: string
-  width?: number
-  height?: number
-  viewBox?: string
-  size?: string | 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+interface IconProps extends SVGIconProps {
   rotate?: number
-  responsive?: boolean
 }
 
 const ChevronIcon = (props: IconProps) => {

--- a/src/components/Icon/Icons/ChevronIcon.tsx
+++ b/src/components/Icon/Icons/ChevronIcon.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import { $icon_md } from '@assets/styles/size/semantics'
+
 import SVGIcon from '@components/Icon/SVGIcon'
 import svgRotate from '@src/helpers/svgRotate'
 
@@ -27,7 +29,7 @@ const ChevronIcon = (props: IconProps) => {
 }
 
 ChevronIcon.defaultProps = {
-  viewBox: '0 0 24 24',
+  viewBox: `0 0 ${$icon_md} ${$icon_md}`,
   rotate: 0,
 }
 

--- a/src/components/Icon/Icons/ChevronIcon.tsx
+++ b/src/components/Icon/Icons/ChevronIcon.tsx
@@ -8,7 +8,7 @@ interface IconProps {
   width?: number
   height?: number
   viewBox?: string
-  size?: string | 'icon-xs' | 'icon-sm' | 'icon-md' | 'icon-lg' | 'icon-xl'
+  size?: string | 'xs' | 'sm' | 'md' | 'lg' | 'xl'
   rotate?: number
   responsive?: boolean
 }

--- a/src/components/Icon/Icons/ChevronIcon.tsx
+++ b/src/components/Icon/Icons/ChevronIcon.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+
+import SVGIcon from '@components/Icon/SVGIcon'
+import svgRotate from '@src/helpers/svgRotate'
+
+interface ChevronProps {
+  color?: string
+  width?: number
+  height?: number
+  viewBox?: string
+  size?: string | 'icon-xs' | 'icon-sm' | 'icon-md' | 'icon-lg' | 'icon-xl'
+  rotate?: number
+  responsive?: boolean
+}
+
+const ChevronIcon = (props: ChevronProps) => {
+  const { viewBox, rotate } = props
+
+  return (
+    <SVGIcon {...props}>
+      <path
+        d="m9.603 5.21.095.084 5.289 5.298 1.41 1.406-.003.004.002.003-1.406 1.408-5.29 5.295a.994.994 0 0 1-1.313.084l-.095-.084a.997.997 0 0 1 0-1.408l5.288-5.298-5.289-5.299a.997.997 0 0 1 0-1.409.994.994 0 0 1 1.312-.083z"
+        transform={svgRotate(rotate, viewBox)}
+      />
+    </SVGIcon>
+  )
+}
+
+ChevronIcon.defaultProps = {
+  viewBox: '0 0 24 24',
+  rotate: 0,
+}
+
+export default ChevronIcon

--- a/src/components/Icon/SVGIcon.tsx
+++ b/src/components/Icon/SVGIcon.tsx
@@ -1,9 +1,12 @@
 import React from 'react'
 
+import { $icon02 } from '@assets/styles/color/semantics'
+import { $icon_md } from '@assets/styles/size/semantics'
+
 import cls from '@helpers/class'
 
 export interface IconProps {
-  color?: string
+  color: string
   width: number
   height: number
   viewBox: string
@@ -36,8 +39,9 @@ const SVGIcon = (props: IconProps) => {
 }
 
 SVGIcon.defaultProps = {
-  width: 24,
-  height: 24,
+  color: $icon02,
+  width: $icon_md,
+  height: $icon_md,
   viewBox: '0 0 24 24',
   responsive: false,
 }

--- a/src/components/Icon/SVGIcon.tsx
+++ b/src/components/Icon/SVGIcon.tsx
@@ -4,6 +4,7 @@ import { $icon02 } from '@assets/styles/color/semantics'
 import { $icon_md } from '@assets/styles/size/semantics'
 
 import cls from '@helpers/class'
+import '@components/Icon/Icon.scss'
 
 export interface IconProps {
   color: string
@@ -29,7 +30,7 @@ const SVGIcon = (props: IconProps) => {
       className={
         size && responsive
           ? cls('icon', 'responsive', size.split('-')[1])
-          : size
+          : cls(size)
       }
       {...rest}
     >

--- a/src/components/Icon/SVGIcon.tsx
+++ b/src/components/Icon/SVGIcon.tsx
@@ -41,7 +41,7 @@ SVGIcon.defaultProps = {
   color: $icon02,
   width: $icon_md,
   height: $icon_md,
-  viewBox: `0 0 ${$icon_md} ${$icon_md}`,
+  viewBox: `0 0 24 24`,
   responsive: false,
 }
 

--- a/src/components/Icon/SVGIcon.tsx
+++ b/src/components/Icon/SVGIcon.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+
+import cls from '@helpers/class'
+
+export interface IconProps {
+  color?: string
+  width: number
+  height: number
+  viewBox: string
+  size?: string | 'icon-xs' | 'icon-sm' | 'icon-md' | 'icon-lg' | 'icon-xl'
+  responsive: boolean
+  children: React.ReactNode
+}
+
+const SVGIcon = (props: IconProps) => {
+  const { color, width, height, viewBox, size, responsive, children, ...rest } =
+    props
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={width}
+      height={height}
+      viewBox={viewBox}
+      fill={color}
+      className={
+        size && responsive
+          ? cls('icon', 'responsive', size.split('-')[1])
+          : size
+      }
+      {...rest}
+    >
+      {children}
+    </svg>
+  )
+}
+
+SVGIcon.defaultProps = {
+  width: 24,
+  height: 24,
+  viewBox: '0 0 24 24',
+  responsive: false,
+}
+
+export default SVGIcon

--- a/src/components/Icon/SVGIcon.tsx
+++ b/src/components/Icon/SVGIcon.tsx
@@ -6,7 +6,7 @@ import { $icon_md } from '@assets/styles/size/semantics'
 import cls from '@helpers/class'
 import '@components/Icon/Icon.scss'
 
-export interface IconProps {
+export interface SVGIconProps {
   color: string
   width: number
   height: number
@@ -16,7 +16,7 @@ export interface IconProps {
   children: React.ReactNode
 }
 
-const SVGIcon = (props: IconProps) => {
+const SVGIcon = (props: SVGIconProps) => {
   const { color, width, height, viewBox, size, responsive, children, ...rest } =
     props
 

--- a/src/components/Icon/SVGIcon.tsx
+++ b/src/components/Icon/SVGIcon.tsx
@@ -41,7 +41,7 @@ SVGIcon.defaultProps = {
   color: $icon02,
   width: $icon_md,
   height: $icon_md,
-  viewBox: '0 0 24 24',
+  viewBox: `0 0 ${$icon_md} ${$icon_md}`,
   responsive: false,
 }
 

--- a/src/components/Icon/SVGIcon.tsx
+++ b/src/components/Icon/SVGIcon.tsx
@@ -11,7 +11,7 @@ export interface IconProps {
   width: number
   height: number
   viewBox: string
-  size?: string | 'icon-xs' | 'icon-sm' | 'icon-md' | 'icon-lg' | 'icon-xl'
+  size?: string | 'xs' | 'sm' | 'md' | 'lg' | 'xl'
   responsive: boolean
   children: React.ReactNode
 }
@@ -28,9 +28,7 @@ const SVGIcon = (props: IconProps) => {
       viewBox={viewBox}
       fill={color}
       className={
-        size && responsive
-          ? cls('icon', 'responsive', size.split('-')[1])
-          : cls(size)
+        size && responsive ? cls('icon', 'responsive', size) : cls('icon', size)
       }
       {...rest}
     >

--- a/src/helpers/svgRotate.ts
+++ b/src/helpers/svgRotate.ts
@@ -1,0 +1,12 @@
+import _ from 'lodash'
+
+const svgRotate = (angle: number, viewBox: string): string => {
+  const viewBoxArr = _.map(viewBox.split(' '), _.toNumber)
+
+  const viewBoxWidth = _.isUndefined(viewBoxArr[2]) ? 0 : viewBoxArr[2]
+  const viewBoxHeight = _.isUndefined(viewBoxArr[3]) ? 0 : viewBoxArr[3]
+
+  return `rotate(${angle}, ${viewBoxWidth / 2}, ${viewBoxHeight / 2})`
+}
+
+export default svgRotate


### PR DESCRIPTION
### 1. 작업 내용
- 누락된 icon-responsive-size 를 추가하였습니다.
- icon의 semantics size를 활용하기 위한 default style을 구성하였습니다.
- `direction` parmas보다 사용자가 rotate 방향을 설정하는 것이 활용성이 좋을 것 같아 회전 각도를 전달받는 `rotate` props 로 수정하였습니다.
- 추후 반응형 사이즈에 대응하기 위해 `responsive` boolean props 를 추가하였습니다.
- zeplin 시안의 기본 속성을 명시하였습니다.
    - color: $icon_02
    - width, height: 24px ($icon_md)

※ 추후 동일한 Icon 컴포넌트 생성 작업이 예정되어있어 공통 요소에 대한 수정사항을 사전에 대응하기 위해 해당 PR을 구성하였습니다.

추가적으로 필요할 것이라 예상되는 props에 대해 의견 주셔도 좋습니다~