### PR TITLE
빌드 시 typescript 관련 플러그인 경고 해결

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": "./",
+    "outDir": "./dist",
     "allowJs": true,
     // 이하 모드는 필요에 따라 설정 변경
     "strict": false,
@@ -26,7 +27,13 @@
     "typeRoots": ["./typings", "./src/**/*.ts", "./src/**/*.tsx"],
     "declaration": true,
     "declarationMap": true,
-    "declarationDir": "dist/types"
+    "declarationDir": "dist/types",
+    "paths": {
+      "@src/*": ["src/*"],
+      "@assets/*": ["src/assets/*"],
+      "@components/*": ["src/components/*"],
+      "@helpers/*": ["src/helpers/*"]
+    }
   },
   // "include": ["typings", "src/**/*"],
   "include": ["typings", "./src/**/*.ts", "./src/**/*.tsx"],
@@ -38,11 +45,5 @@
     "src/components/paper/*",
     "src/components/notifications/*",
     "src/components/__tests__/utils.js"
-  ],
-  "paths": {
-    "@src/*": ["src/*"],
-    "@assets/*": ["src/assets/*"],
-    "@components/*": ["src/components/*"],
-    "@helpers/*": ["src/helpers/*"]
-  }
+  ]
 }


### PR DESCRIPTION
### 1. 작업 사항
- build 시 alias path를 resolve 하지 못하는 문제를 해결했습니다.
- 문제 원인은 path 속성이 compilerOptions 외부에 위치한 문제였습니다. compilerOptions 내부로 path 속성을 이동시켜 문제를 해결했습니다.
- 또한 해당 속성만 사용하면 빌드 했을 때 빌드된 파일이 `src/` 에 위치하는 문제가 존재하여 `outDir: './dist'` 속성을 추가하여 빌드 위치를 dist 파일 위치로 고정시켰습니다.

### 2. 스크린샷

#### 개선 전
- alias path 사용
![image](https://user-images.githubusercontent.com/30149272/147311203-833e65fa-fbe7-4c2b-a71f-33ae68dd8b49.png)

- npx tsc 를 통한 typescript build
![image](https://user-images.githubusercontent.com/30149272/147311224-1c3f211b-7b4a-4440-9e06-865132dd2d7d.png)

### 개선 후
- alias path 사용
![image](https://user-images.githubusercontent.com/30149272/147311393-bb11a0a1-b6a2-46d2-9710-6935db62c6df.png)

- npx tsc 를 통한 typescript build
![image](https://user-images.githubusercontent.com/30149272/147311399-eda876eb-f570-4c53-add3-fb9ae198286e.png)
