### PR TITLE
alias path로 type을 import 하지 못하는 버그

### DIFF
--- a/src/components/Icon/IconSet/Action.tsx
+++ b/src/components/Icon/IconSet/Action.tsx
@@ -3,8 +3,7 @@ import styled from 'styled-components'
 
 import IconSet from '@components/Icon/IconSet/IconSet'
 import * as ActionIconModules from '@components/Icon/Icons/Action'
-// Warning: import { SVGIconProps } from '@components/Icon/Icons/SVGIcon' 으로 import 시 propsType 이 정상적으로 반영되지 않는 오류 존재
-import { SVGIconProps } from '../Icons/SVGIcon'
+import { SVGIconProps } from '@components/Icon/Icons/SVGIcon'
 
 const WrapIcons = styled.div`
   display: grid;

--- a/src/components/Icon/IconSet/Navigation.tsx
+++ b/src/components/Icon/IconSet/Navigation.tsx
@@ -3,8 +3,7 @@ import styled from 'styled-components'
 
 import IconSet from '@components/Icon/IconSet/IconSet'
 import * as NavigationIconModules from '@components/Icon/Icons/Navigation'
-// Warning: import { SVGIconProps } from '@components/Icon/Icons/SVGIcon' 으로 import 시 propsType 이 정상적으로 반영되지 않는 오류 존재
-import { SVGIconProps } from '../Icons/SVGIcon'
+import { SVGIconProps } from '@components/Icon/Icons/SVGIcon'
 
 const WrapIcons = styled.div`
   display: grid;

--- a/src/components/Icon/IconSet/Specific.tsx
+++ b/src/components/Icon/IconSet/Specific.tsx
@@ -3,8 +3,7 @@ import styled from 'styled-components'
 
 import IconSet from '@components/Icon/IconSet/IconSet'
 import * as SpecificIconModules from '@components/Icon/Icons/Specific'
-// Warning: import { SVGIconProps } from '@components/Icon/Icons/SVGIcon' 으로 import 시 propsType 이 정상적으로 반영되지 않는 오류 존재
-import { SVGIconProps } from '../Icons/SVGIcon'
+import { SVGIconProps } from '@components/Icon/Icons/SVGIcon'
 
 const WrapIcons = styled.div`
   display: grid;

--- a/src/components/Icon/IconSet/Toggle.tsx
+++ b/src/components/Icon/IconSet/Toggle.tsx
@@ -3,8 +3,7 @@ import styled from 'styled-components'
 
 import IconSet from '@components/Icon/IconSet/IconSet'
 import * as ToggleIconModules from '@components/Icon/Icons/Toggle'
-// Warning: import { SVGIconProps } from '@components/Icon/Icons/SVGIcon' 으로 import 시 propsType 이 정상적으로 반영되지 않는 오류 존재
-import { SVGIconProps } from '../Icons/SVGIcon'
+import { SVGIconProps } from '@components/Icon/Icons/SVGIcon'
 
 const WrapIcons = styled.div`
   display: grid;

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -107,5 +107,7 @@ module.exports = {
     //   ],
     // },
   ],
-  propsParser: require('react-docgen-typescript').withDefaultConfig().parse,
+  propsParser: require('react-docgen-typescript').withCustomConfig(
+    './tsconfig.json',
+  ).parse,
 }


### PR DESCRIPTION
### 1. 작업 사항
- alias path를 사용하여 propsType을 설정할 수 있도록 변경하였습니다.
- `styleguide.config.js` 에서 react-docgen-typescript 의 withDefaultConfig 로 propsType을 파싱하는 설정을 withCustomConfig와  tsconfig.json 파일을 통해 alias path를 접근할 수 있도록 하는 설정으로 변경하였습니다.

### 2. 문제 해결 스크린샷
![image](https://user-images.githubusercontent.com/30149272/147312785-2b405424-b67a-4ca3-8756-c21f10cf472d.png)

- alias path 사용 시
![image](https://user-images.githubusercontent.com/30149272/147312823-bbe3af84-2434-4570-ac92-0eede20ba41a.png)

