### PR TITLE
v0.0.10 버그 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,8 @@
   },
   "files": [
     "dist",
-    "lib",
-    "!dist/test",
-    "!dist/types"
+    "styles.js",
+    "icons.js"
   ],
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -171,5 +171,10 @@
   },
   "engines": {
     "node": "12.x || 14.x"
+  },
+  "exports": {
+    ".": "./dist/index.js",
+    "./icons": "./dist/icons/index.js",
+    "./styles": "./dist/styles/index.js"
   }
 }

--- a/src/components/Color/Colors.tsx
+++ b/src/components/Color/Colors.tsx
@@ -100,6 +100,10 @@ const Box = styled.div`
     text-align: center;
   }
 
+  dd {
+    margin: 0;
+  }
+
   &:not(:last-child) {
     margin-bottom: 20px;
   }

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -60,10 +60,6 @@ module.exports = {
           name: 'Size',
           content: 'src/components/Size/Size.md',
         },
-        {
-          name: 'Font',
-          content: 'src/components/Font/Font.md',
-        },
       ],
     },
     {


### PR DESCRIPTION
### 1. 작업 사항
- entry point 가 npm 에 같이 배포되지 않는 문제를 package.json 에 설치 파일을 지정하고 entry point 를 지정하는 것으로 해결
- styleguide docs의 dd 태그에 github pages 자체 margin 값을 제공해주는 문제 수정
- font size 문서는 font size 관련 모듈 구성 후 추가할 예정
    - npm 으로 배포한 패키지에는 src가 포함되어 있지 않아 MDWalks-UI 처럼 사용할 수 없음

위 수정 사항을 반영하기 위해 v0.0.11 로 수정 배포를 진행합니다.