### PR TITLE
Issue110.Button - focus, loading

### DIFF
--- a/src/assets/styles/shadow/shadow.js
+++ b/src/assets/styles/shadow/shadow.js
@@ -12,4 +12,6 @@ module.exports = {
   $shadow_hover: `inset 5rem 5rem ${colors.$lw_hover_overlay}`,
   $shadow_active: `inset 5rem 5rem ${colors.$lw_active_overlay}`,
   $shadow_dimmed: `inset 5rem 5rem ${colors.$lw_dimmed_overlay}`,
+
+  $shadow_focus: ` 0 0 0 1px ${colors.$lw_white}, 0 0 0 2.5px ${colors.$lw_blue70}`,
 }

--- a/src/assets/styles/shadow/shadow.js
+++ b/src/assets/styles/shadow/shadow.js
@@ -1,5 +1,6 @@
 // tailwindCSS 에서 사용하기 위한 용도
 const colors = require('../color/colors')
+const colorSemantics = require('../color/semantics')
 
 // tailwind.config.js 설정을 위해 CommonJS 방식 사용
 module.exports = {
@@ -9,7 +10,8 @@ module.exports = {
   $shadow_v4: `0 3px 24px 0 ${colors.$lw_shadow_02}`,
 
   // hover, active, dimmed는 기존 background 위에 덮어씌워야 하기 때문에 inset shadow로 설정
-  $shadow_hover: `inset 5rem 5rem ${colors.$lw_hover_overlay}`,
-  $shadow_active: `inset 5rem 5rem ${colors.$lw_active_overlay}`,
-  $shadow_dimmed: `inset 5rem 5rem ${colors.$lw_dimmed_overlay}`,
+  $shadow_hover: `inset 5rem 5rem ${colorSemantics.$hover_primary}`,
+  $shadow_active: `inset 5rem 5rem ${colorSemantics.$active_primary}`,
+  $shadow_dimmed: `inset 5rem 5rem ${colorSemantics.$dimmed_overlay}`,
+  $shadow_focus: ` 0 0 0 1px ${colorSemantics.$layout_01}, 0 0 0 2.5px ${colorSemantics.$focus_primary}`,
 }

--- a/src/assets/styles/shadow/shadow.js
+++ b/src/assets/styles/shadow/shadow.js
@@ -12,6 +12,4 @@ module.exports = {
   $shadow_hover: `inset 5rem 5rem ${colors.$lw_hover_overlay}`,
   $shadow_active: `inset 5rem 5rem ${colors.$lw_active_overlay}`,
   $shadow_dimmed: `inset 5rem 5rem ${colors.$lw_dimmed_overlay}`,
-
-  $shadow_focus: ` 0 0 0 1px ${colors.$lw_white}, 0 0 0 2.5px ${colors.$lw_blue70}`,
 }

--- a/src/components/Button/Button.md
+++ b/src/components/Button/Button.md
@@ -28,7 +28,7 @@ const render = () => (
     <Button variant="danger_primary">Danger</Button>
     <Button variant="danger_tertiary">Danger</Button>
   </div>
-  )
+)
 render()
 ```
 
@@ -285,9 +285,79 @@ const render = () => (
     <WrapButton>
       <span>xl - icon(md)</span>
       <Button variant="danger_tertiary" size="xl" icon>
-        <CloseIcon  />
+        <CloseIcon />
       </Button>
     </WrapButton>
+  </div>
+)
+render()
+```
+
+#### Loading indicator
+
+- by variants
+
+```js
+import Button from '@components/Button/Button'
+
+const render = () => (
+  <div
+    style={{
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      padding: '8px',
+    }}
+  >
+    <Button loading variant="primary">
+      Primary
+    </Button>
+    <Button loading variant="secondary">
+      Secondary
+    </Button>
+    <Button loading variant="tertiary">
+      Tertiary
+    </Button>
+    <Button loading variant="ghost">
+      Ghost
+    </Button>
+    <Button loading variant="danger_primary">
+      Danger
+    </Button>
+    <Button loading variant="danger_tertiary">
+      Danger
+    </Button>
+  </div>
+)
+render()
+```
+
+- by sizes
+
+```js
+import Button from '@components/Button/Button'
+
+const render = () => (
+  <div
+    style={{
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      padding: '8px',
+    }}
+  >
+    <Button loading size="sm">
+      sm - Small
+    </Button>
+    <Button loading size="md">
+      md - Normal
+    </Button>
+    <Button loading size="lg">
+      lg - Large
+    </Button>
+    <Button loading size="xl">
+      xl - ExtraLarge
+    </Button>
   </div>
 )
 render()

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -275,7 +275,7 @@ $variants: 'primary', 'secondary', 'danger_primary', 'ghost', 'tertiary',
   }
 }
 
-%loading-circle {
+%loading-spinner {
   position: absolute;
   content: '';
   top: 50%;
@@ -291,10 +291,12 @@ $variants: 'primary', 'secondary', 'danger_primary', 'ghost', 'tertiary',
   .#{$component}-#{$variant}-loading {
     color: transparent !important;
     &:before {
-      @extend %loading-circle;
+      //spinner background
+      @extend %loading-spinner;
     }
     &:after {
-      @extend %loading-circle;
+      //moving spinner
+      @extend %loading-spinner;
       border-style: solid;
       border-width: 0.2em;
       box-shadow: 0 0 0 1px transparent;

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -287,6 +287,9 @@ $variants: 'primary', 'secondary', 'danger_primary', 'ghost', 'tertiary',
 }
 
 @each $variant in $variants {
+  $white-wheel: #fff transparent transparent; //layout_01
+  $grey-wheel: #535e6a transparent transparent; // layout_emphasize_02
+
   .#{$component}-#{$variant}-loading {
     color: transparent !important;
     & > span > svg {
@@ -313,9 +316,23 @@ $variants: 'primary', 'secondary', 'danger_primary', 'ghost', 'tertiary',
           $variant ==
           'secondary'
       ) {
-        border-color: #fff transparent transparent; //layout_01
+        border-color: $white-wheel;
       } @else {
-        border-color: #535e6a transparent transparent; // layout_emphasize_02
+        border-color: $grey-wheel;
+      }
+    }
+
+    &:hover:after,
+    &:active:after {
+      @if (
+        $variant ==
+          'ghost' or
+          $variant ==
+          'tertiary' or
+          $variant ==
+          'danger_tertiary'
+      ) {
+        border-color: $white-wheel;
       }
     }
   }

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -21,8 +21,10 @@ $variants: 'primary', 'secondary', 'danger_primary', 'ghost', 'tertiary',
     line-height: 100%;
   }
 
-  &:focus {
-    @apply shadow-shadow_focus;
+  &:focus-visible {
+    box-shadow: 0 0 0 1px #fff, 0 0 0 2.5px #094cae;
+    // layout_01, focus_primary
+    // 220221 SCSS 내부에서 직접 semantic color를 사용할 수 없어 위와 같이 설정. 방법 모색해야 함
   }
 }
 
@@ -276,7 +278,7 @@ $variants: 'primary', 'secondary', 'danger_primary', 'ghost', 'tertiary',
 }
 
 %loading-spinner {
-  position: absolute;
+  @apply absolute;
   content: '';
   top: 50%;
   left: 50%;
@@ -284,7 +286,6 @@ $variants: 'primary', 'secondary', 'danger_primary', 'ghost', 'tertiary',
   width: 1.7em;
   height: 1.7em;
   border-radius: 50%;
-  border: 0.2em solid rgba(36, 41, 45, 0.18);
 }
 
 @each $variant in $variants {
@@ -293,15 +294,16 @@ $variants: 'primary', 'secondary', 'danger_primary', 'ghost', 'tertiary',
     &:before {
       //spinner background
       @extend %loading-spinner;
+      border: 0.2em solid rgba(36, 41, 45, 0.18);
     }
     &:after {
       //moving spinner
       @extend %loading-spinner;
-      border-style: solid;
-      border-width: 0.2em;
       box-shadow: 0 0 0 1px transparent;
       animation: button-spin 0.6s linear;
       animation-iteration-count: infinite;
+      border-style: solid;
+      border-width: 0.2em;
       @if (
         $variant ==
           'primary' or
@@ -320,15 +322,11 @@ $variants: 'primary', 'secondary', 'danger_primary', 'ghost', 'tertiary',
 
 @keyframes button-spin {
   from {
-    -webkit-transform: rotate(0deg);
     transform: rotate(0deg);
-    -webkit-transform: rotate(0deg);
     transform: rotate(0deg);
   }
   to {
-    -webkit-transform: rotate(359deg);
     transform: rotate(359deg);
-    -webkit-transform: rotate(359deg);
     transform: rotate(359deg);
   }
 }

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -312,9 +312,9 @@ $variants: 'primary', 'secondary', 'danger_primary', 'ghost', 'tertiary',
           $variant ==
           'secondary'
       ) {
-        border-color: #fff transparent transparent;
+        border-color: #fff transparent transparent; //layout_01
       } @else {
-        border-color: grey transparent transparent;
+        border-color: #535e6a transparent transparent; // layout_emphasize_02
       }
     }
   }

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -297,7 +297,7 @@ $variants: 'primary', 'secondary', 'danger_primary', 'ghost', 'tertiary',
       border: 0.2em solid rgba(36, 41, 45, 0.18);
     }
     &:after {
-      //moving spinner
+      //spinner wheel
       @extend %loading-spinner;
       box-shadow: 0 0 0 1px transparent;
       animation: button-spin 0.6s linear;

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -5,7 +5,7 @@ $variants: 'primary', 'secondary', 'danger_primary', 'ghost', 'tertiary',
   'danger_tertiary';
 
 .#{$component} {
-  @apply cursor-pointer font-bold outline-none transition duration-200 ease-linear relative;
+  @apply bg-background cursor-pointer font-bold outline-none transition duration-200 ease-linear relative;
   & + & {
     @apply ml-spacing_04;
   }
@@ -22,9 +22,7 @@ $variants: 'primary', 'secondary', 'danger_primary', 'ghost', 'tertiary',
   }
 
   &:focus-visible {
-    box-shadow: 0 0 0 1px #fff, 0 0 0 2.5px #094cae;
-    // layout_01, focus_primary
-    // 220221 SCSS 내부에서 직접 semantic color를 사용할 수 없어 위와 같이 설정. 방법 모색해야 함
+    @apply shadow-shadow_focus;
   }
 }
 
@@ -290,9 +288,9 @@ $variants: 'primary', 'secondary', 'danger_primary', 'ghost', 'tertiary',
 
 @each $variant in $variants {
   .#{$component}-#{$variant}-loading {
-    color: transparent;
+    color: transparent !important;
     & > span > svg {
-      fill: transparent;
+      fill: transparent !important;
     }
     &:before {
       //spinner background

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -18,6 +18,10 @@ $component: #{$prefix}-button;
     @apply inline-flex h-full items-center;
     line-height: 100%;
   }
+
+  &:focus {
+    @apply shadow-shadow_focus;
+  }
 }
 
 // By Sizes(px)

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -3,7 +3,7 @@
 $component: #{$prefix}-button;
 
 .#{$component} {
-  @apply cursor-pointer font-bold outline-none transition duration-200 ease-linear;
+  @apply cursor-pointer font-bold outline-none transition duration-200 ease-linear relative;
   & + & {
     @apply ml-spacing_04;
   }
@@ -270,5 +270,52 @@ $component: #{$prefix}-button;
   &:disabled {
     @apply bg-button_disabled text-text_disabled border-none;
     box-shadow: none;
+  }
+}
+
+.#{$component}-loading {
+  color: transparent;
+  &:before {
+    position: absolute;
+    content: '';
+    top: 50%;
+    left: 50%;
+    margin: -0.85em 0 0 -0.85em;
+    width: 1.7em;
+    height: 1.7em;
+    border-radius: 500rem;
+    border: 0.2em solid rgba(36, 41, 45, 0.18);
+  }
+
+  &:after {
+    position: absolute;
+    content: '';
+    top: 50%;
+    left: 50%;
+    margin: -0.85em 0 0 -0.85em;
+    width: 1.7em;
+    height: 1.7em;
+    border-radius: 500rem;
+    border-style: solid;
+    border-width: 0.2em;
+    box-shadow: 0 0 0 1px transparent;
+    animation: button-spin 0.6s linear;
+    animation-iteration-count: infinite;
+    border-color: #fff transparent transparent;
+  }
+}
+
+@keyframes button-spin {
+  from {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
   }
 }

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -1,6 +1,8 @@
 @import '../../assets/styles/global.scss';
 
 $component: #{$prefix}-button;
+$variants: 'primary', 'secondary', 'danger_primary', 'ghost', 'tertiary',
+  'danger_tertiary';
 
 .#{$component} {
   @apply cursor-pointer font-bold outline-none transition duration-200 ease-linear relative;
@@ -273,35 +275,44 @@ $component: #{$prefix}-button;
   }
 }
 
-.#{$component}-loading {
-  color: transparent;
-  &:before {
-    position: absolute;
-    content: '';
-    top: 50%;
-    left: 50%;
-    margin: -0.85em 0 0 -0.85em;
-    width: 1.7em;
-    height: 1.7em;
-    border-radius: 500rem;
-    border: 0.2em solid rgba(36, 41, 45, 0.18);
-  }
+%loading-circle {
+  position: absolute;
+  content: '';
+  top: 50%;
+  left: 50%;
+  margin: -0.85em 0 0 -0.85em; // top50%, left50일때 요소를 중앙에 위치시키기 위함. -width/2 0 0 -height/2
+  width: 1.7em;
+  height: 1.7em;
+  border-radius: 50%;
+  border: 0.2em solid rgba(36, 41, 45, 0.18);
+}
 
-  &:after {
-    position: absolute;
-    content: '';
-    top: 50%;
-    left: 50%;
-    margin: -0.85em 0 0 -0.85em;
-    width: 1.7em;
-    height: 1.7em;
-    border-radius: 500rem;
-    border-style: solid;
-    border-width: 0.2em;
-    box-shadow: 0 0 0 1px transparent;
-    animation: button-spin 0.6s linear;
-    animation-iteration-count: infinite;
-    border-color: #fff transparent transparent;
+@each $variant in $variants {
+  .#{$component}-#{$variant}-loading {
+    color: transparent !important;
+    &:before {
+      @extend %loading-circle;
+    }
+    &:after {
+      @extend %loading-circle;
+      border-style: solid;
+      border-width: 0.2em;
+      box-shadow: 0 0 0 1px transparent;
+      animation: button-spin 0.6s linear;
+      animation-iteration-count: infinite;
+      @if (
+        $variant ==
+          'primary' or
+          $variant ==
+          'danger_primary' or
+          $variant ==
+          'secondary'
+      ) {
+        border-color: #fff transparent transparent;
+      } @else {
+        border-color: grey transparent transparent;
+      }
+    }
   }
 }
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -290,7 +290,10 @@ $variants: 'primary', 'secondary', 'danger_primary', 'ghost', 'tertiary',
 
 @each $variant in $variants {
   .#{$component}-#{$variant}-loading {
-    color: transparent !important;
+    color: transparent;
+    & > span > svg {
+      fill: transparent;
+    }
     &:before {
       //spinner background
       @extend %loading-spinner;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -84,7 +84,7 @@ function renderButton<
           ghostType !== 'default' &&
           cls('button', 'ghost', ghostType),
         icon && cls('button', 'icon'),
-        loading && cls('button', 'loading'),
+        loading && cls('button', variant, 'loading'),
       )}
       style={{
         ...style,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -120,11 +120,3 @@ Button.defaultProps = {
 }
 
 export default Button as typeof renderButton
-
-// focus
-// loading
-
-// 1. loading === true일때, button 안에 있는 텍스트는 보이면 안된다.
-// 2. size마다 spinner의 사이즈는 달라야 한다.
-// 3. variant가 tertiary일 경우 spinner 색상이 달라야 한다.
-// 4. (선택)before, after 가상 선택자 활용하기 (dom에 표시하기엔 자원 낭비)

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -21,6 +21,7 @@ interface ButtonProps {
   size: string | 'sm' | 'md' | 'lg' | 'xl'
   bold: boolean
   icon: boolean
+  loading: boolean
   responsiveHeight: boolean
   id?: string
   style?: object
@@ -41,6 +42,7 @@ function renderButton<
     size,
     bold,
     icon,
+    loading,
     responsiveHeight,
     id,
     style,
@@ -82,6 +84,7 @@ function renderButton<
           ghostType !== 'default' &&
           cls('button', 'ghost', ghostType),
         icon && cls('button', 'icon'),
+        loading && cls('button', 'loading'),
       )}
       style={{
         ...style,
@@ -112,7 +115,16 @@ Button.defaultProps = {
   size: 'md',
   bold: true,
   icon: false,
+  loading: false,
   responsiveHeight: false,
 }
 
 export default Button as typeof renderButton
+
+// focus
+// loading
+
+// 1. loading === true일때, button 안에 있는 텍스트는 보이면 안된다.
+// 2. size마다 spinner의 사이즈는 달라야 한다.
+// 3. variant가 tertiary일 경우 spinner 색상이 달라야 한다.
+// 4. (선택)before, after 가상 선택자 활용하기 (dom에 표시하기엔 자원 낭비)


### PR DESCRIPTION
- close #110 

## 적용 사항
1. focus-visible 적용
   -  키보드 shift를 눌렀을 때의 상태만 핸들링
2. loading 구현
   - variant에 따라 spinner wheel 다른 색상 적용
   - before, after 가상선택자 적용하여 spinner를 DOM에서 그리지 않도록 설정
   - loading 상태일 때 Button 내부 텍스트 및 아이콘 - transparent로 색상 변경됨
   - hover, active일 때 background-color 변경되지 않도록
 
3. 문서 추가
   - variant, size 별 추가

## Next
   - SCSS 내부에서 semantic 사용하는 방법 모색