### PR TITLE
[Dropdown] window 이외 스크롤 계산 버그

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "webpack": "4.44.2"
   },
   "dependencies": {
+    "@floating-ui/react-dom": "^0.7.2",
     "@mdx-js/react": "^1.6.21",
     "antd": "^3.23.4",
     "clsx": "^1.1.1",

--- a/src/components/Dropdown/Dropdown.md
+++ b/src/components/Dropdown/Dropdown.md
@@ -4,18 +4,20 @@
 
 #### Props
 
-|  Props Name  |           Types           | Default |
-| :----------: | :-----------------------: | :-----: |
-| triggerNode  |    React.ReactElement     |         |
-|    isOpen    |          boolean          |         |
-|     size     |        'md', 'lg'         |  'md'   |
-|     icon     |          boolean          |  false  |
-|  placement   | 'left', 'center', 'right' | 'left'  |
-|  scrollable  |          boolean          |  false  |
-|  className   |          string           |         |
-| containerRef |      React.RefObject      |         |
-|   onClose    |         Function          |         |
-|    style     |          object           |         |
+|   Props Name   |           Types           | Default |
+| :------------: | :-----------------------: | :-----: |
+|  triggerNode   |    React.ReactElement     |         |
+|     isOpen     |          boolean          |         |
+|      size      |        'md', 'lg'         |  'md'   |
+|      icon      |          boolean          |  false  |
+|   placement    | 'left', 'center', 'right' | 'left'  |
+|   scrollable   |          boolean          |  false  |
+|   className    |          string           |         |
+|  containerRef  |      React.RefObject      |         |
+|    isPortal    |          boolean          |  false  |
+| portalQueryStr |          string           |         |
+|    onClose     |         Function          |         |
+|     style      |          object           |         |
 
 <br />
 
@@ -34,7 +36,7 @@ const render = () => {
     <div
       style={{
         display: 'flex',
-        height: '150px',
+        height: '200px',
         justifyContent: 'space-around',
       }}
     >
@@ -208,6 +210,46 @@ const render = () => {
           <Dropdown.Item key={`Dropdown__item__${idx}`} label={label} id={id} />
         ))}
       </Dropdown>
+    </div>
+  )
+}
+
+render()
+```
+
+#### portal props
+
+- `isPortal` props 를 통해 Dropdown 을 전역적으로 배치할 수 있습니다.
+- `portalQueryStr` props 를 통해 Portal 위치를 지정할 수 있습니다.
+  - Portal 위치를 지정할 Element 의 쿼리 스트링을 입력합니다.
+  - `portalQueryStr` 을 지정하지 않거나, 해당 쿼리 스트링으로 Element을 찾을 수 없는 경우 Portal 이 적용되는 위치는 document.body 로 자동 지정됩니다.
+
+```js
+import React from 'react'
+import Button from '@components/Button/Button'
+import Dropdown from '@components/Dropdown/Dropdown'
+
+const render = () => {
+  return (
+    <div style={{ height: '80px', overflow: 'scroll' }}>
+      <div
+        style={{
+          display: 'flex',
+          height: '100px',
+          justifyContent: 'space-around',
+        }}
+      >
+        <Dropdown triggerNode={<Button>Dropdown Default</Button>}>
+          <Dropdown.Item label="Edit" id="edit" />
+          <Dropdown.Item label="Dupliate" id="duplicate" />
+          <Dropdown.Item label="Delete" id="delete" />
+        </Dropdown>
+        <Dropdown isPortal triggerNode={<Button>Dropdown Portal</Button>}>
+          <Dropdown.Item label="Edit" id="edit" />
+          <Dropdown.Item label="Dupliate" id="duplicate" />
+          <Dropdown.Item label="Delete" id="delete" />
+        </Dropdown>
+      </div>
     </div>
   )
 }

--- a/src/components/Dropdown/Dropdown.md
+++ b/src/components/Dropdown/Dropdown.md
@@ -36,7 +36,7 @@ const render = () => {
     <div
       style={{
         display: 'flex',
-        height: '200px',
+        height: '150px',
         justifyContent: 'space-around',
       }}
     >

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -134,12 +134,14 @@ const Dropdown = ({
       )
       setFloatingOffset(Math.abs(triggerElWidth - dropdownElWidth) / 2)
     }
+  }, [refs.reference.current, refs.floating.current, placement])
 
+  useEffect(() => {
     return () => {
       refs.reference.current = null
       refs.floating.current = null
     }
-  }, [refs.reference.current, refs.floating.current, placement])
+  }, [])
 
   useOutsideAlerter(dropdownRef, handleClose)
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -58,6 +58,10 @@ const validateCheck = (key: string, target: string) => {
 
 const DropdownContext = createContext(null)
 
+const WrapDropdownList = ({ isPortal, children }) => {
+  return isPortal ? createPortal(children, document.body) : children
+}
+
 const Dropdown = ({
   triggerNode,
   isOpen: propsIsOpen,
@@ -67,6 +71,7 @@ const Dropdown = ({
   scrollable,
   className,
   containerRef,
+  isPortal,
   onClick,
   onClose,
   style,
@@ -152,6 +157,7 @@ Dropdown.defaultProps = {
   icon: false,
   placement: 'left',
   scrollable: false,
+  isPortal: true,
 }
 
 Dropdown.Item = ({

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -2,8 +2,8 @@ import React, {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
-  useRef,
   useState,
 } from 'react'
 import _ from 'lodash'
@@ -26,6 +26,7 @@ interface DropdownProps {
   className?: string
   containerRef?: React.RefObject<HTMLDivElement>
   isPortal?: boolean
+  portalQueryStr?: string
   onClick?: Function
   onClose?: Function
   style?: object
@@ -58,8 +59,10 @@ const validateCheck = (key: string, target: string) => {
 
 const DropdownContext = createContext(null)
 
-const WrapDropdownList = ({ isPortal, children }) => {
-  return isPortal ? createPortal(children, document.body) : children
+const PortalDropdownList = ({ isPortal, portalQueryStr, children }) => {
+  const el = document.querySelector(portalQueryStr) ?? document.body
+
+  return isPortal ? createPortal(children, el) : children
 }
 
 const Dropdown = ({
@@ -72,13 +75,12 @@ const Dropdown = ({
   className,
   containerRef,
   isPortal,
+  portalQueryStr,
   onClick,
   onClose,
   style,
   children,
 }: DropdownProps) => {
-  const dropdownRef = useRef<HTMLDivElement>()
-
   const [isOpen, setIsOpen] = useState(false)
   const [floatingOffset, setFloatingOffset] = useState(0)
 
@@ -143,7 +145,7 @@ const Dropdown = ({
     }
   }, [])
 
-  useOutsideAlerter(dropdownRef, handleClose)
+  useOutsideAlerter(refs.floating, handleClose)
 
   return (
     <DropdownContext.Provider
@@ -157,27 +159,25 @@ const Dropdown = ({
             ref: reference,
             onClick: handleClickOpen,
           })}
-        <WrapDropdownList isPortal={isPortal}>
-          <div ref={dropdownRef}>
-            <dl
-              ref={floating}
-              role="dropdown-menu-list"
-              className={clsx(
-                cls('dropdown', 'list'),
-                cls('dropdown', validateCheck('size', size)),
-                (propsIsOpen ?? isOpen) && cls('dropdown', 'open'),
-                scrollable && cls('dropdown', 'scrollable'),
-                icon && cls('dropdown', 'icon', 'list'),
-                fontClass[validateCheck('size', size)],
-                className,
-              )}
-              onClick={handleClick}
-              style={{ top: y ?? 0, left: x ?? 0, ...style }}
-            >
-              {children}
-            </dl>
-          </div>
-        </WrapDropdownList>
+        <PortalDropdownList isPortal={isPortal} portalQueryStr={portalQueryStr}>
+          <dl
+            ref={floating}
+            role="dropdown-menu-list"
+            className={clsx(
+              cls('dropdown', 'list'),
+              cls('dropdown', validateCheck('size', size)),
+              (propsIsOpen ?? isOpen) && cls('dropdown', 'open'),
+              scrollable && cls('dropdown', 'scrollable'),
+              icon && cls('dropdown', 'icon', 'list'),
+              fontClass[validateCheck('size', size)],
+              className,
+            )}
+            onClick={handleClick}
+            style={{ top: y ?? 0, left: x ?? 0, ...style }}
+          >
+            {children}
+          </dl>
+        </PortalDropdownList>
       </div>
     </DropdownContext.Provider>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1467,6 +1467,26 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@floating-ui/core@^0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-0.7.3.tgz#d274116678ffae87f6b60e90f88cc4083eefab86"
+  integrity sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg==
+
+"@floating-ui/dom@^0.5.3":
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-0.5.4.tgz#4eae73f78bcd4bd553ae2ade30e6f1f9c73fe3f1"
+  integrity sha512-419BMceRLq0RrmTSDxn8hf9R3VCJv2K9PUfugh5JyEFmdjzDo+e8U5EdR8nzKq8Yj1htzLm3b6eQEEam3/rrtg==
+  dependencies:
+    "@floating-ui/core" "^0.7.3"
+
+"@floating-ui/react-dom@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-0.7.2.tgz#0bf4ceccb777a140fc535c87eb5d6241c8e89864"
+  integrity sha512-1T0sJcpHgX/u4I1OzIEhlcrvkUN8ln39nz7fMoE/2HDHrPiMFoOGR7++GYyfUmIQHkkrTinaeQsO3XWubjSvGg==
+  dependencies:
+    "@floating-ui/dom" "^0.5.3"
+    use-isomorphic-layout-effect "^1.1.1"
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -14368,6 +14388,11 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-isomorphic-layout-effect@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
+  integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
### 1. 작업 사항
- window 스크롤 이외 dropdown 을 사용하는 컴포넌트의 스크롤도 같이 dropdown 위치를 계산할 수 있도록 수정하였습니다.
- 스크롤 영역 내부에서 portal이 불필요한 상황을 고려하여 isPortal props를 통해 portal 적용을 선택적으로 할 수 있도록 수정하였습니다.