### PR TITLE
[fix] checkbox propsChecked

### DIFF
--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -33,13 +33,11 @@ const CheckBox = ({
   children,
   onChange,
 }: CheckBoxProps) => {
-  const [checked, setChecked] = useState(
-    defaultChecked || propsChecked || false,
-  )
+  const [checked, setChecked] = useState(defaultChecked)
 
   const handleOnChange = (evt) => {
     const checked = evt.target.checked
-    propsChecked || setChecked(checked)
+    _.isNil(propsChecked) && setChecked(checked)
     onChange && onChange(checked, id)
   }
 
@@ -63,7 +61,7 @@ const CheckBox = ({
       <input
         type="checkbox"
         id={id}
-        checked={checked}
+        checked={_.isNil(propsChecked) ? checked : propsChecked}
         disabled={disabled}
         onChange={handleOnChange}
       />


### PR DESCRIPTION
- propsChecked를 주었음에도 불구하고 자체 state를 형성하여 check 상태 변화 (propsChecked를 boolean type으로 내려주는 경우)
- checkbox propsChecked의 존재 여부를 단순히 falsy로 check하는 것인 문제
- undefined와 boolean type을 체크하는 로직 추가