### PR TITLE
툴팁 렌더 위치 및 초기 오픈 설정 에러 수정

### DIFF
--- a/src/components/Tooltip/Tooltip.md
+++ b/src/components/Tooltip/Tooltip.md
@@ -51,7 +51,7 @@ const render = () => {
       <FlexDiv
         style={{ marginLeft: buttonWidth, whiteSpace: 'nowrap', gap: 4 }}
       >
-        <Tooltip placement="top-left" text="top-left">
+        <Tooltip placement="top-left" text="top-left" defaultOpen>
           <Button variant="tertiary" size="md">
             TOP-LEFT
           </Button>
@@ -202,10 +202,13 @@ import Tooltip from '@components/Tooltip/Tooltip'
 const render = () => {
   return (
     <div style={{ display: 'flex', gap: 12 }}>
-      <Tooltip placement="bottom" text="align left" style={{ width: 100 }}>
-        <Button variant="tertiary" size="md">
-          LEFT
-        </Button>
+      <Tooltip
+        placement="bottom"
+        text="align left"
+        align="left"
+        style={{ width: 100 }}
+      >
+        LEFT
       </Tooltip>
       <Tooltip
         placement="bottom"
@@ -213,9 +216,7 @@ const render = () => {
         align="center"
         style={{ width: 100 }}
       >
-        <Button variant="tertiary" size="md">
-          CENTER
-        </Button>
+        CENTER
       </Tooltip>
       <Tooltip
         placement="bottom"
@@ -223,17 +224,7 @@ const render = () => {
         align="right"
         style={{ width: 100 }}
       >
-        <Button className="ve" variant="tertiary" size="md">
-          RIGHT
-        </Button>
-      </Tooltip>
-      <Tooltip
-        placement="bottom"
-        text="align right"
-        align="right"
-        style={{ width: 100 }}
-      >
-        RRRIGHT
+        <div>RIGHT</div>
       </Tooltip>
     </div>
   )
@@ -252,12 +243,18 @@ import Tooltip from '@components/Tooltip/Tooltip'
 const render = () => {
   return (
     <div style={{ display: 'flex', gap: 12 }}>
-      <Tooltip placement="bottom" text="DEFAULT CARET" hasCaret>
+      <Tooltip placement="bottom" text="DEFAULT CARET" hasCaret defaultOpen>
         <Button variant="tertiary" size="md">
           CARET(DEFAULT)
         </Button>
       </Tooltip>
-      <Tooltip placement="bottom" text="WHITE CARET" hasCaret variant="white">
+      <Tooltip
+        placement="bottom"
+        text="WHITE CARET"
+        hasCaret
+        variant="white"
+        defaultOpen
+      >
         <Button variant="tertiary" size="md">
           CARET(WHITE)
         </Button>

--- a/src/components/Tooltip/Tooltip.md
+++ b/src/components/Tooltip/Tooltip.md
@@ -10,7 +10,7 @@
 |     variant     |                                                      default, white                                                      | default |
 |    hasCaret     |                                                         boolean                                                          |  false  |
 |    isAdjust     |                                                         boolean                                                          |  true   |
-|   defaultOpen   |                                                         boolean                                                          |  false  |
+|      open       |                                                         boolean                                                          |  false  |
 | parentContainer |                                                         function                                                         |         |
 |    className    |                                                          string                                                          |         |
 |      style      |                                                          object                                                          |   {}    |
@@ -51,7 +51,7 @@ const render = () => {
       <FlexDiv
         style={{ marginLeft: buttonWidth, whiteSpace: 'nowrap', gap: 4 }}
       >
-        <Tooltip placement="top-left" text="top-left" defaultOpen>
+        <Tooltip placement="top-left" text="top-left">
           <Button variant="tertiary" size="md">
             TOP-LEFT
           </Button>
@@ -243,18 +243,12 @@ import Tooltip from '@components/Tooltip/Tooltip'
 const render = () => {
   return (
     <div style={{ display: 'flex', gap: 12 }}>
-      <Tooltip placement="bottom" text="DEFAULT CARET" hasCaret defaultOpen>
+      <Tooltip placement="bottom" text="DEFAULT CARET" hasCaret>
         <Button variant="tertiary" size="md">
           CARET(DEFAULT)
         </Button>
       </Tooltip>
-      <Tooltip
-        placement="bottom"
-        text="WHITE CARET"
-        hasCaret
-        variant="white"
-        defaultOpen
-      >
+      <Tooltip placement="bottom" text="WHITE CARET" hasCaret variant="white">
         <Button variant="tertiary" size="md">
           CARET(WHITE)
         </Button>
@@ -428,6 +422,28 @@ const render = () => {
         </Button>
       </Tooltip>
     </FlexWrapper>
+  )
+}
+render()
+```
+
+#### Default Open
+
+```js
+import React from 'react'
+
+import Button from '@components/Button/Button'
+import Tooltip from '@components/Tooltip/Tooltip'
+
+const render = () => {
+  return (
+    <div style={{ display: 'flex', gap: 12 }}>
+      <Tooltip placement="bottom" text="DEFAULT CARET" hasCaret open>
+        <Button variant="tertiary" size="md">
+          Default Open
+        </Button>
+      </Tooltip>
+    </div>
   )
 }
 render()

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -29,7 +29,7 @@ interface TooltipProps {
   text: string | React.ReactElement
   variant?: 'default' | 'white'
   isAdjust?: boolean
-  defaultOpen?: boolean
+  open?: boolean
   hasCaret?: boolean
   zIndex?: number
   className?: string
@@ -148,7 +148,7 @@ const Tooltip = (props: TooltipProps): React.ReactElement => {
     align = 'left',
     hasCaret = false,
     isAdjust = true,
-    defaultOpen = false,
+    open = false,
     parentContainer = null,
     zIndex,
     className: customClassName = '',
@@ -156,7 +156,7 @@ const Tooltip = (props: TooltipProps): React.ReactElement => {
     children,
   } = props
 
-  const [isOpen, setIsOpen] = useState(defaultOpen)
+  const [isOpen, setIsOpen] = useState(open)
 
   const showTooltip = useCallback(() => setIsOpen(true), [])
   const hideTooltip = useCallback(() => setIsOpen(false), [])


### PR DESCRIPTION
툴팁 렌더 위치 및 초기 오픈 설정 에러 수정

- 렌더에러 수정
  - string 등의 React.isValidElement 를 통과하지 못하는 경우는 createElement 를 통해서 일괄 span 을 붙여주는 형태로 변경
```
// 기존
{React.cloneElement(children, props}
...
//변경
{
  React.isValidElement(children)
    ? React.cloneElement(children, _props)
    : React.createElement('span', _props, children)
}
```
  
- defaultOpen 동작 에러
  - getBoundingClientRect 의 경우는 현재 바라보고 있는 뷰 기준으로 동작 사용하는 곳에서는 open 을 하는 시점은 항상 사용자와 맞닿아 있기 때문에 문제가 없으나, scroll 이 존재하는 곳에서 defaultOpen 등이 같이 물리는 경우 정상적으로 보이지 않는 문제 발생
```
 // 스크롤 위치에 따른 getBoundingClientRect 수치 보정 값
const scrollY = window.scrollY || window.pageYOffset
const scrollX = window.scrollX || window.pageXOffset
```